### PR TITLE
Shared object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-LIB = libuinput.so
+LIB = libuinput.a
 LOBJ := libuinput.o
 
-CFLAGS = -fPIC -Wall -ggdb -O2 -I.
-LDFLAGS = -L. -luinput -shared
+CFLAGS = -Wall -ggdb -O2 -I.
+LDFLAGS = -L. -luinput
 
 modules all: lib
 

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-LIB = libuinput.a
+LIB = libuinput.so
 LOBJ := libuinput.o
 
-CFLAGS = -Wall -ggdb -O2 -I.
-LDFLAGS = -L. -luinput
+CFLAGS = -fPIC -Wall -ggdb -O2 -I.
+LDFLAGS = -L. -luinput -shared
 
 modules all: lib
 

--- a/demo/Makefile
+++ b/demo/Makefile
@@ -1,7 +1,7 @@
 LIB = ..
 
 CFLAGS = -Wall -ggdb -O2 -I$(LIB)/
-LDFLAGS = -static -L$(LIB)/ -luinput
+LDFLAGS = -L$(LIB)/ -luinput
 
 DEMOS := keyboard_demo
 


### PR DESCRIPTION
just remove for systems which don't have a static clib -static on the demo. The lib can still remain .a
